### PR TITLE
fixed placeholder names

### DIFF
--- a/multipart-file-upload-s3.sh
+++ b/multipart-file-upload-s3.sh
@@ -5,16 +5,16 @@
 set -x
 
 bucket=multipart-file-upload-bucket-test
-profile='--profile test-aws-profile'
+profile='test-aws-profile'
 upload_id='1B________Tw--' # Hidden for security reasons.
 key='large_test_file'
 
 part_number=0
 
-for f in /home/lucas/aws-upload-test/files/x*
+for f in /home/lucas/aws-upload-test/files/x/*
 do
         ((part_number=part_number+1))
         md5=$(openssl md5 -binary ${f} | base64)
-        aws s3api upload-part --bucket ${bucket} --key $key $profile --part-number $part_number --body ${f} --upload-id ${upload_id} --content-md5 ${md5} | tee -a logs/upload-part.$part_number-s3.log
+        aws s3api upload-part --bucket ${bucket} --key $key --profile $profile --part-number $part_number --body ${f} --upload-id ${upload_id} --content-md5 ${md5} | tee -a logs/upload-part.$part_number-s3.log
         cat logs/upload-part.$part_number-s3.log | awk -F'"' '{print $5}' | cut -f 1 -d '\' | awk NF | awk '{ print "{\"ETag\":\"" $1 "\",\"PartNumber\": '$part_number' }," }' >> logs/output-test.json 
 done


### PR DESCRIPTION
script would fail if you didn't add a trailing / before the *
moved `--profile` our of the variable definition, and into the s3api command params